### PR TITLE
feature/Add case insensitive support for deeplinks

### DIFF
--- a/DeepLinkKit/Regex/DPLRegularExpression.m
+++ b/DeepLinkKit/Regex/DPLRegularExpression.m
@@ -7,7 +7,7 @@ static NSString * const DPLURLParameterPattern        = @"([^/]+)";
 @implementation DPLRegularExpression
 
 + (instancetype)regularExpressionWithPattern:(NSString *)pattern {
-    return [[self alloc] initWithPattern:pattern options:0 error:nil];
+    return [[self alloc] initWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:nil];
 }
 
 

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -136,8 +136,7 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  }
  @endcode
  */
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key
-NS_SWIFT_UNAVAILABLE("Available in Swift as: register(route: String, routeHandlerBlock: (DPLDeepLink) -> ())");
+- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
 
 
 /**
@@ -147,6 +146,6 @@ NS_SWIFT_UNAVAILABLE("Available in Swift as: register(route: String, routeHandle
  @endcode
  @note The type of the returned handler is the type you registered for that route.
  */
-- (id)objectForKeyedSubscript:(NSString *)key NS_SWIFT_UNAVAILABLE("Not Available");
+- (id)objectForKeyedSubscript:(NSString *)key;
 
 @end

--- a/Tests/Regex/DPLRegularExpressionSpec.m
+++ b/Tests/Regex/DPLRegularExpressionSpec.m
@@ -40,7 +40,26 @@ describe(@"Matching named components", ^{
         DPLMatchResult *matchResult = [expression matchResultForString:@"/hello/dovalue/thisvalue/and/thatvalue"];
         expect(matchResult.match).to.beFalsy();
     });
-    
+
+    it(@"should match named components without regex but case insensitive", ^{
+        DPLRegularExpression *expression = [DPLRegularExpression regularExpressionWithPattern:@"/hello/:do/:this/and/:that"];
+
+        DPLMatchResult *matchResult = [expression matchResultForString:@"/hEllo/dOvalue/Thisvalue/and/THATvalue"];
+        expect(matchResult.match).to.beTruthy();
+        expect(matchResult.namedProperties).to.equal(@{ @"do": @"dOvalue",
+                                                        @"this": @"Thisvalue",
+                                                        @"that": @"THATvalue" });
+    });
+
+    it(@"should match named components with regex case insensitive", ^{
+        DPLRegularExpression *expression = [DPLRegularExpression regularExpressionWithPattern:@"/hello/:do([a-zA-Z]+)/:this([a-zA-Z]+)/and/:that([a-zA-Z]+)"];
+
+        DPLMatchResult *matchResult = [expression matchResultForString:@"/hEllo/dOvalue/Thisvalue/and/THATvalue"];
+        expect(matchResult.match).to.beTruthy();
+        expect(matchResult.namedProperties).to.equal(@{ @"do": @"dOvalue",
+                                                        @"this": @"Thisvalue",
+                                                        @"that": @"THATvalue" });
+    });
 });
 
 SpecEnd


### PR DESCRIPTION
Overview:
- Now deep links are handled regardless of case insensitivity.
- Enable subscript in Swift since we’re not using blocks. It was removed in latest release because of failure when assigning block instead of class.