### PR TITLE
Feature/before and after each blocks

### DIFF
--- a/DeepLinkKit/Router/DPLDeepLinkRouter.h
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.h
@@ -67,6 +67,17 @@ typedef void(^DPLRouteCompletionBlock)(BOOL handled, NSError *error);
  */
 - (void)registerBlock:(DPLRouteHandlerBlock)routeHandlerBlock forRoute:(NSString *)route;
 
+/**
+Registers a block executed before each route.
+@param routeHandlerBlock A block to be executed before the supported route is matched.
+*/
+- (void)registerBeforeEachBlock:(DPLRouteHandlerBlock)routeHandlerBlock;
+
+/**
+Registers a block executed after each route.
+@param routeHandlerBlock A block to be executed after the supported route is matched.
+*/
+- (void)registerAfterEachBlock:(DPLRouteHandlerBlock)routeHandlerBlock;
 
 /**
  A Swift friendly version of -registerBlock:forRoute:

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -132,9 +132,9 @@
         return NO;
     }
 
-    DPLRouteMatcher *rootMatcher = [DPLRouteMatcher matcherWithRoute:""];
+    DPLRouteMatcher *rootMatcher = [DPLRouteMatcher matcherWithRoute:@""];
     if (self.beforeEachBlock) {
-        self.beforeEachBlock([rootMatcher deepLinkWithURL:url])
+        self.beforeEachBlock([rootMatcher deepLinkWithURL:url]);
     }
 
     NSError      *error;
@@ -150,7 +150,7 @@
     }
 
     if (self.afterEachBlock) {
-        self.afterEachBlock([rootMatcher deepLinkWithURL:url])
+        self.afterEachBlock([rootMatcher deepLinkWithURL:url]);
     }
     
     if (!deepLink) {

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -65,13 +65,13 @@
 
 - (void)registerBeforeEachBlock:(DPLRouteHandlerBlock)routeHandlerBlock {
     if (routeHandlerBlock) {
-        self.beforeEachBlock = [routeHandlerBlock copy];
+        self.beforeEachBlock = routeHandlerBlock;
     }
 }
 
 - (void)registerAfterEachBlock:(DPLRouteHandlerBlock)routeHandlerBlock {
     if (routeHandlerBlock) {
-        self.afterEachBlock = [routeHandlerBlock copy];
+        self.afterEachBlock = routeHandlerBlock;
     }
 }
 

--- a/DeepLinkKit/Router/DPLDeepLinkRouter.m
+++ b/DeepLinkKit/Router/DPLDeepLinkRouter.m
@@ -132,11 +132,6 @@
         return NO;
     }
 
-    DPLRouteMatcher *rootMatcher = [DPLRouteMatcher matcherWithRoute:@""];
-    if (self.beforeEachBlock) {
-        self.beforeEachBlock([rootMatcher deepLinkWithURL:url]);
-    }
-
     NSError      *error;
     DPLDeepLink  *deepLink;
     __block BOOL isHandled = NO;
@@ -144,15 +139,18 @@
         DPLRouteMatcher *matcher = [DPLRouteMatcher matcherWithRoute:route];
         deepLink = [matcher deepLinkWithURL:url];
         if (deepLink) {
+            if (self.beforeEachBlock) {
+                self.beforeEachBlock(deepLink);
+            }
             isHandled = [self handleRoute:route withDeepLink:deepLink error:&error];
+            if (self.afterEachBlock) {
+                self.afterEachBlock(deepLink);
+            }
             break;
         }
     }
 
-    if (self.afterEachBlock) {
-        self.afterEachBlock([rootMatcher deepLinkWithURL:url]);
-    }
-    
+
     if (!deepLink) {
         NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: NSLocalizedString(@"The passed URL does not match a registered route.", nil) };
         error = [NSError errorWithDomain:DPLErrorDomain code:DPLRouteNotFoundError userInfo:userInfo];


### PR DESCRIPTION
## Description

We have added a `BeforeEach` and `AfterEach` blocks to our fork of DeepLinkKit, the blocks are executed when app is processing the supported deeplink.

This allows to specify a shared logic before and after deeplink processing without duplicating the logic between route handlers

