### PR TITLE
feature/ Escape plus sign

### DIFF
--- a/DeepLinkKit/Categories/NSString+DPLQuery.m
+++ b/DeepLinkKit/Categories/NSString+DPLQuery.m
@@ -22,7 +22,8 @@
         if (pairs.count == 2) {
             // e.g. ?key=value
             NSString *key   = [pairs[0] DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-            NSString *value = [pairs[1] DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            NSString *value = [[pairs[1] stringByReplacingOccurrencesOfString:@"+" withString:@" "]
+                               DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             paramsDict[key] = value;
         }
         else if (pairs.count == 1) {


### PR DESCRIPTION
Added support for decoding `+` sign that tends to be used as whitespace encoding symbol. We're doing the replacement before default decoding so that the actual `+` in param is not mistakenly replaced with whitespace.


Will be tested within: https://github.com/thefabulous/fabulous-ios/pull/1903